### PR TITLE
Check if expirationDate is really defined

### DIFF
--- a/src/app/core/models/instance.model.ts
+++ b/src/app/core/models/instance.model.ts
@@ -287,7 +287,7 @@ export class Instance {
     }
 
     public willExpireInHours(hours: number): boolean {
-        if (this.expirationDate != null) {
+        if (this.expirationDate instanceof Date) {
             const durationS = (this.expirationDate.getTime() - new Date().getTime());
             return durationS < hours * 60 * 60 * 1000;
         }

--- a/src/app/user/instance-list/card/card.component.ts
+++ b/src/app/user/instance-list/card/card.component.ts
@@ -347,7 +347,7 @@ export class CardComponent implements OnInit, OnDestroy {
     }
 
     private updateExpirationCountdown(): void {
-        if (this.instance.expirationDate) {
+        if (this.instance.expirationDate instanceof Date) {
             const second = 1000;
             const minute = second * 60;
             const hour = minute * 60;


### PR DESCRIPTION
Since visa-api-server version 3.1.2, the "Connect" button is not enabled once the instance becomes active. (see https://github.com/ILLGrenoble/visa-api-server/issues/23)

We see many times the following error:
this.expirationDate.getTime is not a function in two functions: 
- instance.model.ts#willExpireInHours(hours: number)
- card.component.ts#updateExpirationCountdown()

We've fixed the problem by using instanceof to check if the expiration date is really defined.