### PR TITLE
Add python to system deps to build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:22-alpine AS builder
 COPY package.json package-lock.json ./
 
 RUN apk update
-RUN apk add --no-cache git
+RUN apk add --no-cache git python3 py3-setuptools make g++
 
 # build
 RUN npm install --legacy-peer-deps && mkdir /visa-web && mv ./node_modules ./visa-web


### PR DESCRIPTION
While trying to build the image locally it was complaining about missing deps in the alpine distribution:
```
[1/2] STEP 1/7: FROM node:22-alpine AS builder
[1/2] STEP 2/7: COPY package.json package-lock.json ./
--> Using cache 2451909f0c96416d70a0f86357bb9621952e2da9d291361d2de145835e925446
--> 2451909f0c96
[1/2] STEP 3/7: RUN apk update
--> Using cache 8f297fb80008a135d7976f847463ca0d6458e3f844db87d6cb89c3014a37b195
--> 8f297fb80008
[1/2] STEP 4/7: RUN npm install --legacy-peer-deps && mkdir /visa-web && mv ./node_modules ./visa-web
npm error code 1
npm error path /node_modules/@parcel/watcher
npm error command failed
npm error command sh -c node-gyp-build
npm error gyp info it worked if it ends with ok
npm error gyp info using node-gyp@9.4.0
npm error gyp info using node@22.21.1 | linux | arm64
npm error (node:27) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
npm error (Use `node --trace-deprecation ...` to show where the warning was created)
npm error gyp ERR! find Python 
npm error gyp ERR! find Python Python is not set from command line or npm configuration
npm error gyp ERR! find Python Python is not set from environment variable PYTHON
npm error gyp ERR! find Python checking if "python3" can be used
npm error gyp ERR! find Python - "python3" is not in PATH or produced an error
npm error gyp ERR! find Python checking if "python" can be used
npm error gyp ERR! find Python - "python" is not in PATH or produced an error
npm error gyp ERR! find Python 
npm error gyp ERR! find Python **********************************************************
npm error gyp ERR! find Python You need to install the latest version of Python.
npm error gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
npm error gyp ERR! find Python you can try one of the following options:
npm error gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
npm error gyp ERR! find Python   (accepted by both node-gyp and npm)
npm error gyp ERR! find Python - Set the environment variable PYTHON
npm error gyp ERR! find Python - Set the npm configuration variable python:
npm error gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
npm error gyp ERR! find Python For more information consult the documentation at:
npm error gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
npm error gyp ERR! find Python **********************************************************
npm error gyp ERR! find Python 
npm error gyp ERR! configure error 
npm error gyp ERR! stack Error: Could not find any Python installation to use
npm error gyp ERR! stack     at PythonFinder.fail (/node_modules/node-gyp/lib/find-python.js:330:47)
npm error gyp ERR! stack     at PythonFinder.runChecks (/node_modules/node-gyp/lib/find-python.js:159:21)
npm error gyp ERR! stack     at PythonFinder.<anonymous> (/node_modules/node-gyp/lib/find-python.js:202:16)
npm error gyp ERR! stack     at PythonFinder.execFileCallback (/node_modules/node-gyp/lib/find-python.js:294:16)
npm error gyp ERR! stack     at exithandler (node:child_process:424:5)
npm error gyp ERR! stack     at ChildProcess.errorhandler (node:child_process:436:5)
npm error gyp ERR! stack     at ChildProcess.emit (node:events:519:28)
npm error gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
npm error gyp ERR! stack     at onErrorNT (node:internal/child_process:483:16)
npm error gyp ERR! stack     at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
npm error gyp ERR! System Linux 6.15.10-200.fc42.aarch64
npm error gyp ERR! command "/usr/local/bin/node" "/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
npm error gyp ERR! cwd /node_modules/@parcel/watcher
npm error gyp ERR! node -v v22.21.1
npm error gyp ERR! node-gyp -v v9.4.0
npm error gyp ERR! not ok
npm notice
npm notice New major version of npm available! 10.9.4 -> 11.7.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.7.0
npm notice To update run: npm install -g npm@11.7.0
npm notice
npm error A complete log of this run can be found in: /root/.npm/_logs/2025-12-16T13_34_42_103Z-debug-0.log
Error: building at STEP "RUN npm install --legacy-peer-deps && mkdir /visa-web && mv ./node_modules ./visa-web": while running runtime: exit status 1
```

I was able to build the image after adding these deps.