### PR TITLE
CI: Update GitHub Actions Docker workflow versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,11 +15,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -29,14 +29,14 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7.2.0
         with:
           context    : .
           file       : ./Dockerfile


### PR DESCRIPTION
These github actions versions are long deprecated, and hopefully bumping them up shouldn't cause much damage :)